### PR TITLE
Add SOLPLUS 25 firmware 2.53 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The integration keeps the lifetime sensor stable across temporary inverter outag
 | SOLPLUS 100 | ✅ | Fully supported |
 | SOLPLUS 50 | ⚠️ | Expected to work |
 | SOLPLUS 35 | ⚠️ | Expected to work |
+| SOLPLUS 25 | ✅ | Supported with firmware 2.53 legacy HTML |
 
 If you own another model, please share an `index.html` or `stat.xml` sample to improve compatibility.
 

--- a/custom_components/solutronic/coordinator.py
+++ b/custom_components/solutronic/coordinator.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import timedelta
 
 from bs4 import BeautifulSoup
@@ -33,6 +34,7 @@ class SolutronicDataUpdateCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.entry = entry
         self._last_data = None  # Store last known valid data for fallback
+        self.supported_keys = set()
 
         # Lifetime counter internal state
         self._lt_prev_et = None
@@ -81,6 +83,8 @@ class SolutronicDataUpdateCoordinator(DataUpdateCoordinator):
                 model_new = self.device_model
                 firmware_new = self.device_firmware
 
+                text = soup.get_text("\n", strip=True)
+
                 # Extract manufacturer and model from <h1> header
                 header = soup.find("h1")
                 if header is not None:
@@ -93,8 +97,19 @@ class SolutronicDataUpdateCoordinator(DataUpdateCoordinator):
                         model_new = parts[0]
                         manufacturer_new = parts[1]
 
+                # Extract metadata from legacy SOLPLUS basic menu pages.
+                legacy_header = re.search(
+                    r"(SOLPLUS\s+\d+),\s*S/N\s+(\d+),\s*FW-Version\s+([\d.]+)",
+                    text,
+                    re.IGNORECASE,
+                )
+                if legacy_header is not None:
+                    manufacturer_new = "Solutronic"
+                    model_new = " ".join(legacy_header.group(1).split()).upper()
+                    self.device_serial = legacy_header.group(2)
+                    firmware_new = legacy_header.group(3)
+
                 # Extract firmware version
-                text = soup.get_text("\n", strip=True)
                 for line in text.split("\n"):
                     if "FW-Release:" not in line:
                         continue
@@ -133,6 +148,8 @@ class SolutronicDataUpdateCoordinator(DataUpdateCoordinator):
 
             if pac_values:
                 data["PAC_TOTAL"] = sum(pac_values)
+            elif isinstance(data.get("PAC"), (int, float)):
+                data["PAC_TOTAL"] = data["PAC"]
             else:
                 data.pop("PAC_TOTAL", None)
 
@@ -176,6 +193,7 @@ class SolutronicDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Store latest valid dataset for fallback use
             self._last_data = data
+            self.supported_keys.update(key for key, value in data.items() if value is not None)
             if self._offline_logged:
                 _LOGGER.info("Solutronic inverter at %s is reachable again", self.ip_address)
                 self._offline_logged = False
@@ -211,11 +229,13 @@ class SolutronicDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Set zero-values for momentary readings
             for key in zero_keys:
-                fallback[key] = 0
+                if key in self.supported_keys or key in last:
+                    fallback[key] = 0
 
             # Restore ET + EG + Derived total if known
             for key in retain_keys:
-                fallback[key] = last.get(key, 0)
+                if key in self.supported_keys or key in last:
+                    fallback[key] = last.get(key, 0)
 
             self._last_data = fallback
             return fallback

--- a/custom_components/solutronic/manifest.json
+++ b/custom_components/solutronic/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "solutronic",
   "name": "Solutronic",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "documentation": "https://github.com/Ralleberg/solutronic",
   "requirements": ["beautifulsoup4"],
   "codeowners": ["@Ralleberg"],

--- a/custom_components/solutronic/sensor.py
+++ b/custom_components/solutronic/sensor.py
@@ -81,7 +81,7 @@ class SolutronicSensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self):
         """Return True if the coordinator has successfully updated at least once."""
-        return self.coordinator.last_update_success
+        return self.coordinator.last_update_success and self._key in (self.coordinator.data or {})
 
     @property
     def device_info(self):

--- a/custom_components/solutronic/solutronic_api.py
+++ b/custom_components/solutronic/solutronic_api.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup
 import asyncio
 import ipaddress
 import logging
+import re
 from urllib.parse import urlsplit
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -25,6 +26,7 @@ KNOWN_SENSOR_KEYS = {
     "IDC1", "IDC2", "IDC3", "ET", "EG", "SN", "MAXP", "ETA",
     "UACL1", "UACL2", "UACL3",
 }
+TELEMETRY_SENSOR_KEYS = KNOWN_SENSOR_KEYS - {"SN"}
 
 
 class SolutronicConnectionError(ConnectionError):
@@ -84,7 +86,17 @@ async def _fetch_text(session, url: str, timeout: aiohttp.ClientTimeout) -> str:
 
 
 def _parse_sensor_data(html_data: str) -> dict:
-    """Parse inverter telemetry from the Solutronic HTML table."""
+    """Parse inverter telemetry from supported Solutronic HTML layouts."""
+    data = _parse_table_sensor_data(html_data)
+    if TELEMETRY_SENSOR_KEYS.intersection(data):
+        return data
+
+    legacy_data = _parse_basic_menu_sensor_data(html_data)
+    return legacy_data or data
+
+
+def _parse_table_sensor_data(html_data: str) -> dict:
+    """Parse telemetry from newer Solutronic table layouts."""
     soup = BeautifulSoup(html_data, "html.parser")
     table = soup.find("table")
     data = {}
@@ -111,10 +123,64 @@ def _parse_sensor_data(html_data: str) -> dict:
     return data
 
 
+def _to_float(value: str):
+    """Convert a Solutronic number string to float."""
+    return float(value.replace(",", ".").strip())
+
+
+def _extract_labeled_number(text: str, label: str):
+    """Extract the numeric value after a label from the legacy basic menu page."""
+    match = re.search(
+        rf"{re.escape(label)}\s*:\s*([+-]?\d+(?:[.,]\d+)?)",
+        text,
+        re.IGNORECASE,
+    )
+    if match is None:
+        return None
+
+    return _to_float(match.group(1))
+
+
+def _parse_basic_menu_sensor_data(html_data: str) -> dict:
+    """Parse telemetry from old SOLPLUS basic menu HTML pages."""
+    soup = BeautifulSoup(html_data, "html.parser")
+    text = soup.get_text("\n", strip=True)
+
+    if "webserver for solplus" not in text.lower() and "solplus" not in text.lower():
+        return {}
+
+    data = {}
+
+    label_map = {
+        "power AC": "PAC",
+        "mains voltage": "UACL1",
+        "DC voltage": "UDC1",
+        "DC-current": "IDC1",
+        "energy today": "ET",
+        "energy total": "EG",
+        "efficiency": "ETA",
+        "maximum power today": "MAXP",
+    }
+
+    for label, key in label_map.items():
+        value = _extract_labeled_number(text, label)
+        if value is not None:
+            data[key] = value
+
+    if "PAC" in data:
+        data.setdefault("PACL1", data["PAC"])
+
+    serial_match = re.search(r"S/N\s+(\d+)", text, re.IGNORECASE)
+    if serial_match is not None:
+        data["SN"] = serial_match.group(1)
+
+    return data
+
+
 def _looks_like_solutronic_page(html_data: str) -> bool:
     """Return True only for pages that look like a Solutronic inverter page."""
     data = _parse_sensor_data(html_data)
-    if KNOWN_SENSOR_KEYS.intersection(data):
+    if TELEMETRY_SENSOR_KEYS.intersection(data):
         return True
 
     lower_html = html_data.lower()
@@ -216,7 +282,7 @@ async def async_get_sensor_data(ip_address: str, hass=None):
                 html_data = await _fetch_text(session, base, timeout)
 
     data = _parse_sensor_data(html_data)
-    if not KNOWN_SENSOR_KEYS.intersection(data):
+    if not TELEMETRY_SENSOR_KEYS.intersection(data):
         raise SolutronicInvalidResponseError("Endpoint did not return Solutronic telemetry")
 
     return data


### PR DESCRIPTION
Adds support for SOLPLUS 25 firmware 2.53 where stat.xml returns legacy HTML instead of XML.

Fixes parsing of:
- power AC
- mains voltage
- DC voltage
- DC current
- energy today
- energy total
- efficiency
- maximum power today
- model, serial and firmware metadata

Unsupported sensors are now marked unavailable instead of unknown.

Closes #2
